### PR TITLE
update agent kill problem

### DIFF
--- a/agent/bin/agent-cmd.sh
+++ b/agent/bin/agent-cmd.sh
@@ -254,8 +254,8 @@ start () {
 
 stop () {
     chk_agent_exist
-    #kill $chdpid
-    killall -9 $agentpath
+    kill $chdpid
+    #killall -9 $agentpath
     echo "$agent stop."
 }
 

--- a/agent/qconf_agent.cc
+++ b/agent/qconf_agent.cc
@@ -241,8 +241,9 @@ static void sig_handler(int sig)
     case SIGTERM:
     case SIGUSR2:
         qconf_thread_exit();
-        qconf_agent_destroy();
-        exit(0);
+        //qconf_agent_destroy();
+        break;
+        //chang // exit(0);
     case SIGHUP:
         break;
     case SIGUSR1:

--- a/agent/qconf_const.h
+++ b/agent/qconf_const.h
@@ -3,6 +3,9 @@
 
 #include "qconf_common.h"
 
+//change++++++++++++++++++++++++++++++++
+#define QCONF_STOP_MSG_QUEUE                "MSG_END"
+//+++++++++++++++++++++++++++++++++++++
 // agent version
 #define QCONF_AGENT_VERSION                 "1.0.2"
 

--- a/agent/qconf_watcher.cc
+++ b/agent/qconf_watcher.cc
@@ -186,6 +186,7 @@ int qconf_init_msg_key()
 void qconf_thread_exit()
 {
     _stop_watcher_setting = true;
+    send_msg(_msg_queue_id, QCONF_STOP_MSG_QUEUE);
     _watch_nodes_cond.SignalAll();
     _change_trigger_cond.SignalAll();
     _gray_idcs_cond.SignalAll();
@@ -331,6 +332,9 @@ static void *msg_process(void *p)
         int ret = receive_msg(_msg_queue_id, key);
         if (QCONF_OK == ret)
         {
+            if ( key == QCONF_STOP_MSG_QUEUE ) {
+                continue;
+            }
             add_watcher_node(key);
         }
         else if (QCONF_ERR_MSGIDRM == ret)


### PR DESCRIPTION
问题描述：
agent-cmd.sh中停止agent用 Kill 的方式由于msg线程阻塞等待消息会导致程序杀不掉
master中使用kill -9,但是这种方式会导致agent的zk客户端无法释放临时节点，导致快速重启不成功

解决办法：
继续用kill命令停止程序，agent收到信号后像msg发送一个特殊的命令“MSG_END”
此时msg线程退出，调用destroy函数正常释放资源，解决了该问题
