### PR TITLE
readme中idc.conf配置格式有误

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ vi QCONF_INSTALL_PREFIX/conf/idc.conf
 ``` php
   # all the zookeeper host configuration.
   #[zookeeper]
-  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183 #zookeeper of idc 'test'
+  
+  #zookeeper of idc 'test'
+  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183
 ```
  - **Assign** local idc
 ``` 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -46,7 +46,9 @@ vi QCONF_INSTALL_PREFIX/conf/idc.conf
 ``` php
   #all the zookeeper host configuration.
   #[zookeeper]
-  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183 #test机房zookeeper配置
+  
+  #test机房zookeeper配置
+  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183
 ```
  - 在QConf配置文件中指定本地机房
 ``` shell

--- a/doc/QConf Getting Started Guide.md
+++ b/doc/QConf Getting Started Guide.md
@@ -43,7 +43,9 @@ vi QCONF_INSTALL_PREFIX/conf/idc.conf
 ``` php
   # all the zookeeper host configuration.
   #[zookeeper]
-  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183 #zookeeper of idc 'test'
+  
+  #zookeeper of idc 'test'
+  zookeeper.test=127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183
 ```
  - **Assign** local idc
 ``` shell


### PR DESCRIPTION
“#”注释必须放在每行开头，否则解析失败产生以下报错：

2019/01/18 17:51:00 - [pid: 19513][ERROR][qconf_config.cc 137] - error happened when execute regex error: No match
2019/01/18 17:51:00 - [pid: 19513][ERROR][qconf_config.cc 212] - Invalid of ip_port: 127.0.0.1:2182
2019/01/18 17:51:00 - [pid: 19513][ERROR][qconf_config.cc 334] - Invalid ips of idc! line_num:8, idc:product, value:127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183